### PR TITLE
double check passphrase when init db

### DIFF
--- a/zerodbext/server/manage.py
+++ b/zerodbext/server/manage.py
@@ -53,7 +53,7 @@ def auth_options(f):
         global _passphrase
         global _sock
         
-	_username=str(username)
+        _username=str(username)
         _passphrase=str(passphrase)
 
         if sock.startswith("/"):

--- a/zerodbext/server/manage.py
+++ b/zerodbext/server/manage.py
@@ -44,29 +44,18 @@ def cli():
 
 def auth_options(f):
     """Decorator to enable username, passphrase and sock options to command"""
-    @click.option("--username", default=None, type=click.STRING, help="Admin username")
-    @click.option("--passphrase", default=None, type=click.STRING, help="Admin passphrase or hex private key")
-    @click.option("--sock", default="localhost:8001", type=click.STRING, help="Storage server socket (TCP or UNIX)")
+    @click.option("--username", prompt="Username", default="root", type=click.STRING, help="Admin username")
+    @click.option("--passphrase", prompt="Passphrase", hide_input=True, confirmation_prompt=True, type=click.STRING, help="Admin passphrase or hex private key")
+    @click.option("--sock", prompt="Sock", default="localhost:8001", type=click.STRING, help="Storage server socket (TCP or UNIX)")
     @click.pass_context
     def auth_func(ctx, username, passphrase, sock, *args, **kw):
         global _username
         global _passphrase
         global _sock
+        
+	_username=str(username)
+        _passphrase=str(passphrase)
 
-        if username:
-            _username = str(username)
-        else:
-            _username = str(click.prompt("Username", default="root"))
-
-        if passphrase:
-            _passphrase = str(passphrase)
-        else:
-            while True:
-                _passphrase = str(click.prompt("Passphrase", hide_input=True))
-                _passphrase1 = str(click.prompt("Passphrase input again", hide_input=True))
-                if _passphrase == _passphrase1:
-                    break
-                    
         if sock.startswith("/"):
             _sock = sock
         else:

--- a/zerodbext/server/manage.py
+++ b/zerodbext/server/manage.py
@@ -61,8 +61,12 @@ def auth_options(f):
         if passphrase:
             _passphrase = str(passphrase)
         else:
-            _passphrase = str(click.prompt("Passphrase", hide_input=True))
-
+            while True:
+                _passphrase = str(click.prompt("Passphrase", hide_input=True))
+                _passphrase1 = str(click.prompt("Passphrase input again", hide_input=True))
+                if _passphrase == _passphrase1:
+                    break
+                    
         if sock.startswith("/"):
             _sock = sock
         else:


### PR DESCRIPTION
User may misspell the passphrase which he wants when init db. Let user input twice to ensure they are the same may be helpful. 
