### PR TITLE
Consolidate the two requirements.txt files; add zope.interface

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,3 +1,6 @@
-zerodb-server
 loremipsum
 names
+ipython>=1.0.0
+click
+zope.interface>=4.2.0
+zerodb==0.98.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ipython>=1.0.0
 click
+zope.interface>=4.2.0
 zerodb==0.98.0


### PR DESCRIPTION
At least on Ubuntu Trusty, the default zope.interface is too old.
